### PR TITLE
feature: [new rule] Duplicate parameter name feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Each rule links to its own documentation page.
 | Rule | Description | ✅ | Severity in `all` | 🔧 |
 | :--- | :--- | :---: | :---: | :---: |
 | [param-name-mismatch](https://github.com/ouka-lab/eslint-plugin-hono/blob/master/docs/rules/param-name-mismatch.md) | Ensure parameter name in `c.req.param()` matches the route definition | ✅ | 🚨 error | |
+| [no-duplicate-path-params](https://github.com/ouka-lab/eslint-plugin-hono/blob/master/docs/rules/no-duplicate-path-params.md) | Disallow declaring the same path parameter name twice in one route path (`/users/:id/posts/:id`) | ✅ | 🚨 error | |
 | [no-multiple-next](https://github.com/ouka-lab/eslint-plugin-hono/blob/master/docs/rules/no-multiple-next.md) | Disallow multiple calls to `next()` in a single middleware execution path | ✅ | 🚨 error | |
 | [no-unused-context-response](https://github.com/ouka-lab/eslint-plugin-hono/blob/master/docs/rules/no-unused-context-response.md) | Disallow unused calls to Context response methods (`c.json`, `c.text`, etc.) | ✅ | 🚨 error | |
 | [prefer-http-exception](https://github.com/ouka-lab/eslint-plugin-hono/blob/master/docs/rules/prefer-http-exception.md) | Suggest using `HTTPException` instead of generic `Error` for HTTP errors | ✅ | ⚠️ warn | |

--- a/docs/rules/no-duplicate-path-params.md
+++ b/docs/rules/no-duplicate-path-params.md
@@ -1,0 +1,48 @@
+# hono/no-duplicate-path-params
+
+Disallow declaring the same path parameter name twice in a route path.
+
+✅ Enabled in the `recommended` and `all` configs (🚨 `error`).
+
+Hono accepts a path like `/users/:id/posts/:id` without complaint, but the duplicate name is not an error you find out about at startup — it silently collapses. Only the first `:id` is captured, so `c.req.param('id')` always returns the user id and the post id is unreachable. Nothing throws and nothing 404s; the route simply reads the wrong value forever. This rule catches the typo where you meant two different names.
+
+The check looks at a single path string only, so it covers the path passed to `get`, `post`, `put`, `patch`, `delete`, `options`, `all`, `use`, `on`, `route` and `basePath`. Paths composed across `app.route()` boundaries are not analysed, because the sub app usually lives in another file.
+
+## Examples
+
+**Incorrect**
+
+```typescript
+const app = new Hono();
+
+app.get('/users/:id/posts/:id', (c) => {
+  // Always the user id — the second ':id' is unreachable
+  const id = c.req.param('id');
+  return c.text(id);
+});
+
+// Regexp constraints do not make the names distinct
+app.get('/post/:date{[0-9]+}/:date{[a-z]+}', (c) => c.text('ok'));
+
+// Mount paths and middleware paths are checked too
+app.use('/users/:id/:id', mw);
+app.route('/users/:id/:id', sub);
+```
+
+**Correct**
+
+```typescript
+const app = new Hono();
+
+app.get('/users/:userId/posts/:postId', (c) => {
+  const userId = c.req.param('userId');
+  const postId = c.req.param('postId');
+  return c.text(`${userId}/${postId}`);
+});
+
+app.get('/post/:date{[0-9]+}/:title{[a-z]+}', (c) => c.text('ok'));
+```
+
+---
+
+[← Back to all rules](../../README.md#rules)

--- a/docs/rules/no-duplicate-path-params.md
+++ b/docs/rules/no-duplicate-path-params.md
@@ -6,7 +6,7 @@ Disallow declaring the same path parameter name twice in a route path.
 
 Hono accepts a path like `/users/:id/posts/:id` without complaint, but the duplicate name is not an error you find out about at startup — it silently collapses. Only the first `:id` is captured, so `c.req.param('id')` always returns the user id and the post id is unreachable. Nothing throws and nothing 404s; the route simply reads the wrong value forever. This rule catches the typo where you meant two different names.
 
-The check looks at a single path string only, so it covers the path passed to `get`, `post`, `put`, `patch`, `delete`, `options`, `all`, `use`, `on`, `route` and `basePath`. Paths composed across `app.route()` boundaries are not analysed, because the sub app usually lives in another file.
+The check looks at a single path string only, so it covers the path passed to `get`, `post`, `put`, `patch`, `delete`, `options`, `all`, `use`, `on`, `route`, `mount` and `basePath`. Paths composed across `app.route()` boundaries are not analysed, because the sub app usually lives in another file.
 
 ## Examples
 

--- a/docs/rules/no-duplicate-path-params.md
+++ b/docs/rules/no-duplicate-path-params.md
@@ -6,7 +6,7 @@ Disallow declaring the same path parameter name twice in a route path.
 
 Hono accepts a path like `/users/:id/posts/:id` without complaint, but the duplicate name is not an error you find out about at startup — it silently collapses. Only the first `:id` is captured, so `c.req.param('id')` always returns the user id and the post id is unreachable. Nothing throws and nothing 404s; the route simply reads the wrong value forever. This rule catches the typo where you meant two different names.
 
-The check looks at a single path string only, so it covers the path passed to `get`, `post`, `put`, `patch`, `delete`, `options`, `all`, `use`, `on`, `route`, `mount` and `basePath`. Paths composed across `app.route()` boundaries are not analysed, because the sub app usually lives in another file.
+The check examines each literal path string passed to `get`, `post`, `put`, `patch`, `delete`, `options`, `all`, `use`, `on`, `route`, `mount` and `basePath`, including literal path arrays. Parameter names follow Hono's own grammar, so `/u/:user-id/:user-name` is two distinct parameters, not one. Paths composed across `app.route()` boundaries are not analysed, because the sub-app usually lives in another file.
 
 ## Examples
 
@@ -41,6 +41,9 @@ app.get('/users/:userId/posts/:postId', (c) => {
 });
 
 app.get('/post/:date{[0-9]+}/:title{[a-z]+}', (c) => c.text('ok'));
+
+// '-' is part of the name: these are two different parameters
+app.get('/u/:user-id/:user-name', (c) => c.text('ok'));
 ```
 
 ---

--- a/playground/src/no-duplicate-path-params.ts
+++ b/playground/src/no-duplicate-path-params.ts
@@ -1,0 +1,18 @@
+// hono/no-duplicate-path-params
+// A route path must not declare the same `:param` name twice.
+// docs: https://github.com/ouka-lab/eslint-plugin-hono/blob/master/docs/rules/no-duplicate-path-params.md
+import { Hono } from 'hono';
+
+const app = new Hono();
+
+// ❌ no-duplicate-path-params: ':id' is declared twice, so only the user id is captured and the post id is unreachable
+app.get('/users/:id/posts/:id', (c) => {
+  return c.text(c.req.param('id'));
+});
+
+// ✅ ok
+app.get('/users/:userId/posts/:postId', (c) => {
+  return c.text(`${c.req.param('userId')}/${c.req.param('postId')}`);
+});
+
+export default app;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { noMultipleNext } from './rules/no-multiple-next';
 import { noUnusedContextResponse } from './rules/no-unused-context-response';
 import { noProcessEnv } from './rules/no-process-env';
 import { globalMiddlewarePlacement } from './rules/global-middleware-placement';
+import { noDuplicatePathParams } from './rules/no-duplicate-path-params';
 
 const rules = {
   'route-grouping': routeGrouping,
@@ -16,6 +17,7 @@ const rules = {
   'no-unused-context-response': noUnusedContextResponse,
   'no-process-env': noProcessEnv,
   'global-middleware-placement': globalMiddlewarePlacement,
+  'no-duplicate-path-params': noDuplicatePathParams,
 };
 
 const withPrefix = <R extends Linter.RulesRecord>(rules: R) =>
@@ -34,6 +36,7 @@ const withPrefix = <R extends Linter.RulesRecord>(rules: R) =>
  */
 const recommendedRules = {
   'param-name-mismatch': 'error',
+  'no-duplicate-path-params': 'error',
   'no-multiple-next': 'error',
   'no-unused-context-response': 'error',
   'prefer-http-exception': 'warn',
@@ -47,6 +50,7 @@ const allRules = {
   'no-unused-context-response': 'error',
   'no-process-env': 'warn',
   'global-middleware-placement': 'warn',
+  'no-duplicate-path-params': 'error',
 } as const satisfies Linter.RulesRecord;
 
 const plugin = {

--- a/src/rules/no-duplicate-path-params.test.ts
+++ b/src/rules/no-duplicate-path-params.test.ts
@@ -63,9 +63,19 @@ ruleTester.run(
       const app = new Hono();
       app.get(\`/users/\${prefix}/:id/:id\`, (c) => c.text('ok'));
     `,
+      // A tagged template is not a route path. It is also the only place where
+      // the parser produces a null `cooked`, so reading it must stay guarded.
+      `
+      const app = new Hono();
+      app.get(sql\`/users/:id/:id\`, (c) => c.text('ok'));
+    `,
       // Not a route path: does not start with '/'
       `
       cache.get('foo::bar::bar');
+    `,
+      // Same, written as a template literal
+      `
+      cache.get(\`foo::bar::bar\`);
     `,
       // A bare ':' is not a param
       `

--- a/src/rules/no-duplicate-path-params.test.ts
+++ b/src/rules/no-duplicate-path-params.test.ts
@@ -33,6 +33,26 @@ ruleTester.run(
       const app = new Hono();
       app.get('/posts/:id/:id2', (c) => c.text('ok'));
     `,
+      // Hono allows '-' and '.' in a parameter name, so these are two distinct
+      // parameters and must not be truncated to a shared prefix
+      `
+      const app = new Hono();
+      app.get('/u/:user-id/:user-name', (c) => c.text('ok'));
+    `,
+      `
+      const app = new Hono();
+      app.get('/u/:a.b/:a.c', (c) => c.text('ok'));
+    `,
+      // A ':' in the middle of a segment is not a parameter
+      `
+      const app = new Hono();
+      app.get('/foo:bar/:bar', (c) => c.text('ok'));
+    `,
+      // Distinct hyphenated names on a mount path
+      `
+      const app = new Hono();
+      app.mount('/a/:user-id/:user-name', anotherApp);
+    `,
       // Regexp params with distinct names
       `
       const app = new Hono();
@@ -189,6 +209,19 @@ ruleTester.run(
         app.mount('/a/:id/:id', anotherApp);
       `,
         errors: [{ messageId: 'duplicateParam' }],
+      },
+      // mount() with hyphenated names: still a genuine duplicate
+      {
+        code: `
+        const app = new Hono();
+        app.mount('/a/:user-id/b/:user-id', anotherApp);
+      `,
+        errors: [
+          {
+            message:
+                            'Route path \'/a/:user-id/b/:user-id\' declares \':user-id\' more than once. Give each path parameter a unique name.',
+          },
+        ],
       },
       // basePath
       {

--- a/src/rules/no-duplicate-path-params.test.ts
+++ b/src/rules/no-duplicate-path-params.test.ts
@@ -182,6 +182,14 @@ ruleTester.run(
       `,
         errors: [{ messageId: 'duplicateParam' }],
       },
+      // mount(): the base path of a foreign application handler
+      {
+        code: `
+        const app = new Hono();
+        app.mount('/a/:id/:id', anotherApp);
+      `,
+        errors: [{ messageId: 'duplicateParam' }],
+      },
       // basePath
       {
         code: `

--- a/src/rules/no-duplicate-path-params.test.ts
+++ b/src/rules/no-duplicate-path-params.test.ts
@@ -1,0 +1,221 @@
+import { RuleTester } from 'eslint';
+import { noDuplicatePathParams } from './no-duplicate-path-params';
+import * as parser from '@typescript-eslint/parser';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser,
+  },
+});
+
+ruleTester.run(
+  'no-duplicate-path-params',
+  noDuplicatePathParams as unknown as import('eslint').Rule.RuleModule,
+  {
+    valid: [
+      // Distinct param names
+      `
+      const app = new Hono();
+      app.get('/users/:userId/posts/:postId', (c) => c.text('ok'));
+    `,
+      // Single param
+      `
+      const app = new Hono();
+      app.get('/users/:id', (c) => c.text('ok'));
+    `,
+      // No params at all
+      `
+      const app = new Hono();
+      app.get('/hello', (c) => c.text('ok'));
+    `,
+      // ':id' and ':id2' are different names
+      `
+      const app = new Hono();
+      app.get('/posts/:id/:id2', (c) => c.text('ok'));
+    `,
+      // Regexp params with distinct names
+      `
+      const app = new Hono();
+      app.get('/post/:date{[0-9]+}/:title{[a-z]+}', (c) => c.text('ok'));
+    `,
+      // Nested braces inside a regexp constraint are skipped, not read as names
+      `
+      const app = new Hono();
+      app.get('/files/:name{\\\\d{4}}/:other', (c) => c.text('ok'));
+    `,
+      // Optional param followed by a different one
+      `
+      const app = new Hono();
+      app.get('/posts/:id?/comments/:commentId', (c) => c.text('ok'));
+    `,
+      // Wildcard has no name
+      `
+      const app = new Hono();
+      app.get('/wildcard/*', (c) => c.text('ok'));
+    `,
+      // use() without a path argument
+      `
+      const app = new Hono();
+      app.use(logger());
+    `,
+      // Template literal with an expression is not analysable
+      `
+      const app = new Hono();
+      app.get(\`/users/\${prefix}/:id/:id\`, (c) => c.text('ok'));
+    `,
+      // Not a route path: does not start with '/'
+      `
+      cache.get('foo::bar::bar');
+    `,
+      // A bare ':' is not a param
+      `
+      const app = new Hono();
+      app.get('/a/:/b/:', (c) => c.text('ok'));
+    `,
+      // Non-member call is ignored
+      `
+      get('/users/:id/:id');
+    `,
+      // Computed member access is ignored
+      `
+      const app = new Hono();
+      app[method]('/users/:id/:id', (c) => c.text('ok'));
+    `,
+      // A method that takes no route path
+      `
+      const app = new Hono();
+      app.fire('/users/:id/:id');
+    `,
+      // on() with only a method argument
+      `
+      const app = new Hono();
+      app.on('GET');
+    `,
+      // Sparse array of paths
+      `
+      const app = new Hono();
+      app.on('GET', [, '/users/:id'], (c) => c.text('ok'));
+    `,
+    ],
+    invalid: [
+      // The canonical case
+      {
+        code: `
+        const app = new Hono();
+        app.get('/users/:id/posts/:id', (c) => c.text('ok'));
+      `,
+        errors: [{ messageId: 'duplicateParam' }],
+      },
+      // Three occurrences still report once
+      {
+        code: `
+        const app = new Hono();
+        app.get('/a/:id/b/:id/c/:id', (c) => c.text('ok'));
+      `,
+        errors: [{ messageId: 'duplicateParam' }],
+      },
+      // Two distinct duplicated names report twice
+      {
+        code: `
+        const app = new Hono();
+        app.get('/a/:x/:x/b/:y/:y', (c) => c.text('ok'));
+      `,
+        errors: [
+          { messageId: 'duplicateParam' },
+          { messageId: 'duplicateParam' },
+        ],
+      },
+      // Other HTTP methods
+      {
+        code: `
+        const app = new Hono();
+        app.post('/users/:id/:id', (c) => c.text('ok'));
+      `,
+        errors: [{ messageId: 'duplicateParam' }],
+      },
+      {
+        code: `
+        const app = new Hono();
+        app.delete('/users/:id/:id', (c) => c.text('ok'));
+      `,
+        errors: [{ messageId: 'duplicateParam' }],
+      },
+      // Middleware
+      {
+        code: `
+        const app = new Hono();
+        app.use('/users/:id/:id', mw);
+      `,
+        errors: [{ messageId: 'duplicateParam' }],
+      },
+      // on(): the path is the second argument
+      {
+        code: `
+        const app = new Hono();
+        app.on('GET', '/users/:id/posts/:id', (c) => c.text('ok'));
+      `,
+        errors: [{ messageId: 'duplicateParam' }],
+      },
+      // on() with an array of paths
+      {
+        code: `
+        const app = new Hono();
+        app.on(['GET', 'POST'], ['/a/:x/:x'], (c) => c.text('ok'));
+      `,
+        errors: [{ messageId: 'duplicateParam' }],
+      },
+      // Mount path of a sub app
+      {
+        code: `
+        const app = new Hono();
+        app.route('/users/:id/:id', sub);
+      `,
+        errors: [{ messageId: 'duplicateParam' }],
+      },
+      // basePath
+      {
+        code: `
+        const app = new Hono().basePath('/:v/:v');
+      `,
+        errors: [{ messageId: 'duplicateParam' }],
+      },
+      // Regexp params sharing a name
+      {
+        code: `
+        const app = new Hono();
+        app.get('/post/:date{[0-9]+}/:date{[a-z]+}', (c) => c.text('ok'));
+      `,
+        errors: [
+          {
+            message:
+                            'Route path \'/post/:date{[0-9]+}/:date{[a-z]+}\' declares \':date\' more than once. Give each path parameter a unique name.',
+          },
+        ],
+      },
+      // One of the two is optional
+      {
+        code: `
+        const app = new Hono();
+        app.get('/posts/:id/comments/:id?', (c) => c.text('ok'));
+      `,
+        errors: [{ messageId: 'duplicateParam' }],
+      },
+      // Template literal without expressions
+      {
+        code: `
+        const app = new Hono();
+        app.get(\`/users/:id/posts/:id\`, (c) => c.text('ok'));
+      `,
+        errors: [{ messageId: 'duplicateParam' }],
+      },
+      // Method chaining
+      {
+        code: `
+        const app = new Hono();
+        app.get('/a/:id', (c) => c.text('ok')).get('/b/:x/:x', (c) => c.text('ok'));
+      `,
+        errors: [{ messageId: 'duplicateParam' }],
+      },
+    ],
+  },
+);

--- a/src/rules/no-duplicate-path-params.ts
+++ b/src/rules/no-duplicate-path-params.ts
@@ -1,0 +1,163 @@
+import { TSESTree } from '@typescript-eslint/utils';
+import { createRule } from '../utils';
+
+type Options = [];
+type MessageIds = 'duplicateParam';
+
+/**
+ * Methods that take a route path, mapped to the index of the path argument.
+ * `on()` is the odd one out: its first argument is the HTTP method.
+ */
+const PATH_ARG_INDEX: Record<string, number> = {
+  get: 0,
+  post: 0,
+  put: 0,
+  patch: 0,
+  delete: 0,
+  options: 0,
+  all: 0,
+  use: 0,
+  route: 0,
+  basePath: 0,
+  on: 1,
+};
+
+const NAME_CHAR = /[a-zA-Z0-9_]/;
+
+/**
+ * Collect the `:name` parameters declared in a Hono route path.
+ *
+ * Scanning character by character rather than with a single regex is what
+ * makes `:date{\d{4}}` work: the braces of a regexp constraint nest, so the
+ * constraint has to be skipped by counting them.
+ */
+function extractPathParams(path: string): string[] {
+  const params: string[] = [];
+  let i = 0;
+
+  while (i < path.length) {
+    if (path[i] !== ':') {
+      i++;
+      continue;
+    }
+
+    let j = i + 1;
+    while (j < path.length && NAME_CHAR.test(path[j])) j++;
+
+    if (j === i + 1) {
+      // A bare ':' with no name — not a parameter.
+      i++;
+      continue;
+    }
+
+    params.push(path.slice(i + 1, j));
+
+    if (path[j] === '{') {
+      let depth = 0;
+      while (j < path.length) {
+        const char = path[j];
+        if (char === '\\') {
+          j += 2;
+          continue;
+        }
+        if (char === '{') {
+          depth++;
+        }
+        else if (char === '}') {
+          depth--;
+          if (depth === 0) {
+            j++;
+            break;
+          }
+        }
+        j++;
+      }
+    }
+
+    if (path[j] === '?') j++;
+
+    i = j;
+  }
+
+  return params;
+}
+
+/** A route path is always a string that starts with '/'. */
+function getRoutePath(node: TSESTree.Node): string | null {
+  if (node.type === 'Literal' && typeof node.value === 'string') {
+    return node.value.startsWith('/') ? node.value : null;
+  }
+
+  if (node.type === 'TemplateLiteral' && node.quasis.length === 1) {
+    const raw = node.quasis[0].value.cooked;
+    return raw.startsWith('/') ? raw : null;
+  }
+
+  return null;
+}
+
+export const noDuplicatePathParams = createRule<Options, MessageIds>({
+  name: 'no-duplicate-path-params',
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+                'Disallow declaring the same path parameter name twice in a route path',
+    },
+    schema: [],
+    messages: {
+      duplicateParam:
+                'Route path \'{{routePath}}\' declares \':{{paramName}}\' more than once. Give each path parameter a unique name.',
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    function checkPathNode(node: TSESTree.Node) {
+      const routePath = getRoutePath(node);
+      if (routePath === null) return;
+
+      const seen = new Set<string>();
+      const reported = new Set<string>();
+
+      for (const name of extractPathParams(routePath)) {
+        if (!seen.has(name)) {
+          seen.add(name);
+          continue;
+        }
+        if (reported.has(name)) continue;
+        reported.add(name);
+
+        context.report({
+          node,
+          messageId: 'duplicateParam',
+          data: { routePath, paramName: name },
+        });
+      }
+    }
+
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type !== 'MemberExpression'
+          || node.callee.property.type !== 'Identifier'
+        )
+          return;
+
+        const index = PATH_ARG_INDEX[node.callee.property.name];
+        if (index === undefined) return;
+
+        const pathArg = node.arguments[index];
+        if (!pathArg) return;
+
+        if (pathArg.type === 'ArrayExpression') {
+          for (const element of pathArg.elements) {
+            if (element) checkPathNode(element);
+          }
+          return;
+        }
+
+        checkPathNode(pathArg);
+      },
+    };
+  },
+});

--- a/src/rules/no-duplicate-path-params.ts
+++ b/src/rules/no-duplicate-path-params.ts
@@ -23,61 +23,57 @@ const PATH_ARG_INDEX: Record<string, number> = {
   on: 1,
 };
 
-const NAME_CHAR = /[a-zA-Z0-9_]/;
+/**
+ * Hono's own parameter grammar (`getPattern` in `hono/utils/url`): a parameter
+ * takes a whole path segment, and its name is anything but braces, followed by
+ * an optional `{regexp}` constraint.
+ *
+ * Matching this exactly matters. Hono really does capture `/u/:user-id` as
+ * `user-id` and `/u/:a.b` as `a.b`, so a name cut short at the first non-word
+ * character would turn two distinct parameters into a false duplicate.
+ */
+const PARAM_SEGMENT = /^:([^{}]+)(?:\{.+\})?$/;
+
+/**
+ * Split a route path into segments the way Hono does, without breaking a
+ * `{regexp}` constraint that itself contains a '/'.
+ */
+function splitRoutingPath(path: string): string[] {
+  const segments: string[] = [];
+  let current = '';
+  let depth = 0;
+
+  for (const char of path) {
+    if (char === '{') depth++;
+    else if (char === '}' && depth > 0) depth--;
+
+    if (char === '/' && depth === 0) {
+      segments.push(current);
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  segments.push(current);
+
+  return segments;
+}
 
 /**
  * Collect the `:name` parameters declared in a Hono route path.
  *
- * Scanning character by character rather than with a single regex is what
- * makes `:date{\d{4}}` work: the braces of a regexp constraint nest, so the
- * constraint has to be skipped by counting them.
+ * This mirrors Hono's grammar rather than approximating it, because a name the
+ * scanner truncates turns two distinct parameters into a false duplicate.
  */
 function extractPathParams(path: string): string[] {
   const params: string[] = [];
-  let i = 0;
 
-  while (i < path.length) {
-    if (path[i] !== ':') {
-      i++;
-      continue;
-    }
-
-    let j = i + 1;
-    while (j < path.length && NAME_CHAR.test(path[j])) j++;
-
-    if (j === i + 1) {
-      // A bare ':' with no name — not a parameter.
-      i++;
-      continue;
-    }
-
-    params.push(path.slice(i + 1, j));
-
-    if (path[j] === '{') {
-      let depth = 0;
-      while (j < path.length) {
-        const char = path[j];
-        if (char === '\\') {
-          j += 2;
-          continue;
-        }
-        if (char === '{') {
-          depth++;
-        }
-        else if (char === '}') {
-          depth--;
-          if (depth === 0) {
-            j++;
-            break;
-          }
-        }
-        j++;
-      }
-    }
-
-    if (path[j] === '?') j++;
-
-    i = j;
+  for (const segment of splitRoutingPath(path)) {
+    const match = PARAM_SEGMENT.exec(segment);
+    if (!match) continue;
+    // `/posts/:id?` captures the key as `id`, so the optional marker is not
+    // part of the name.
+    params.push(match[1].replace(/\?$/, ''));
   }
 
   return params;

--- a/src/rules/no-duplicate-path-params.ts
+++ b/src/rules/no-duplicate-path-params.ts
@@ -89,8 +89,9 @@ function getRoutePath(node: TSESTree.Node): string | null {
   }
 
   if (node.type === 'TemplateLiteral' && node.quasis.length === 1) {
-    const raw = node.quasis[0].value.cooked;
-    return raw.startsWith('/') ? raw : null;
+    // `cooked` is null when the template holds an invalid escape sequence.
+    const cooked = node.quasis[0].value.cooked;
+    return cooked && cooked.startsWith('/') ? cooked : null;
   }
 
   return null;

--- a/src/rules/no-duplicate-path-params.ts
+++ b/src/rules/no-duplicate-path-params.ts
@@ -18,6 +18,7 @@ const PATH_ARG_INDEX: Record<string, number> = {
   all: 0,
   use: 0,
   route: 0,
+  mount: 0,
   basePath: 0,
   on: 1,
 };


### PR DESCRIPTION
# PR Summary

resolves: #21 

# Checklist

- [x] Add or fix test code
- [x] Add or fix README
- [x] Add or fix docs/*.md by using skill `/rule-docs`
- [x] Add or fix playground/src/*.ts by using skill `/rule-playground`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added a lint rule that detects duplicate parameter names in route paths.
* Enabled the rule as an error in the recommended and all configurations.
* Supports routes, middleware, mounts, path arrays, templates, optional parameters, and regular-expression constraints.

## Documentation
* Added guidance with valid and invalid examples.
* Added a playground example demonstrating duplicate and distinct path parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->